### PR TITLE
fix refresh e.g. single backup/restore task

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.java
+++ b/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.java
@@ -476,7 +476,7 @@ public class MainActivityX extends BaseActivity implements BatchConfirmDialog.Co
     public void refresh(boolean mainBoolean, boolean backupOrAppSheetBoolean, List<String> checkedList) {
         Log.d(MainActivityX.TAG, "refreshing");
         runOnUiThread(() -> {
-            binding.refreshLayout.setRefreshing(true);
+            binding.refreshLayout.setRefreshing(true);  //TODO: hg42 refresh can run in parallel, needs counting or multiple (overlaying?) Spinners
             searchViewController.clean();
         });
         badgeCounter = 0;

--- a/app/src/main/java/com/machiav3lli/backup/fragments/AppSheet.java
+++ b/app/src/main/java/com/machiav3lli/backup/fragments/AppSheet.java
@@ -394,7 +394,7 @@ public class AppSheet extends BottomSheetDialogFragment implements ActionListene
     public void onActionCalled(BackupRestoreHelper.ActionType actionType, int mode) {
         if (actionType == BackupRestoreHelper.ActionType.BACKUP) {
             new BackupTask(this.app, handleMessages, requireMainActivity(), backupDir, MainActivityX.getShellHandlerInstance(), mode).execute();
-            requireMainActivity().refreshWithAppSheet();
+            //TODO: hg42: requireMainActivity().refreshWithAppSheet();  // too early...seems to prevent later refresh (check it! if so, why?)
         } else if (actionType == BackupRestoreHelper.ActionType.RESTORE) {
             // Latest Backup for now
             BackupItem selectedBackup = this.app.getLatestBackup();

--- a/app/src/main/java/com/machiav3lli/backup/tasks/BaseTask.java
+++ b/app/src/main/java/com/machiav3lli/backup/tasks/BaseTask.java
@@ -80,6 +80,7 @@ public abstract class BaseTask extends AsyncTask<Void, Void, Integer> {
             }
             UIUtils.showActionResult(mainActivityX, this.result, null);
         }
+        mainActivityX.refreshWithAppSheet();
         if (signal != null) {
             signal.countDown();
         }


### PR DESCRIPTION
backing up a single entry didn't get a refresh.
Additionally, I had a case where something wasn't refreshed because two refreshes were running in parallel (I tried to change this, but a Java Thread cannot be stopped from outside and from inside didn't work either, but that's another story).
Anyways, it doesn't make much sense to start a refresh thread before an action (especially when caching), so I removed this.
All refresh invocations are now at the end of some action.

I also added a TODO, because parallel refreshes only show the spinner while the first one is running, because it is reset after the each refresh (and it is only bool)