### PR TITLE
cache directories and invalidate it before getApplicationList

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/handler/BackendController.java
+++ b/app/src/main/java/com/machiav3lli/backup/handler/BackendController.java
@@ -32,6 +32,7 @@ public final class BackendController {
 
     public static List<AppInfoV2> getApplicationList(Context context, boolean includeUninstalled)
             throws FileUtils.BackupLocationInAccessibleException, PrefUtils.StorageLocationNotConfiguredException {
+        StorageFile.invalidateCache();
         PackageManager pm = context.getPackageManager();
         StorageFile backupRoot = DocumentHelper.getBackupRoot(context);
         List<PackageInfo> packageInfoList = pm.getInstalledPackages(0);

--- a/app/src/main/java/com/machiav3lli/backup/handler/StorageFile.java
+++ b/app/src/main/java/com/machiav3lli/backup/handler/StorageFile.java
@@ -15,10 +15,14 @@ import com.machiav3lli.backup.Constants;
 
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 @RequiresApi(26)
 public class StorageFile {
     static final String TAG = Constants.classTag(".StorageFile");
+    static Map<String, StorageFile[]> cache;
+    static boolean cacheDirty = true;
 
     @Nullable
     private final StorageFile parent;
@@ -64,6 +68,10 @@ public class StorageFile {
         }
     }
 
+    public static void invalidateCache() {
+        StorageFile.cacheDirty = true;
+    }
+
     @Nullable
     public StorageFile findFile(@NonNull String displayName) {
         try {
@@ -82,33 +90,42 @@ public class StorageFile {
         if(!this.exists()){
             throw new FileNotFoundException("File " + this.uri + " does not exist");
         }
-        final ContentResolver resolver = this.context.getContentResolver();
-        final Uri childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(this.uri,
-                DocumentsContract.getDocumentId(this.uri));
-        final ArrayList<Uri> results = new ArrayList<>();
-        Cursor cursor = null;
-        //noinspection OverlyBroadCatchBlock
-        try {
-            cursor = resolver.query(childrenUri, new String[]{
-                    DocumentsContract.Document.COLUMN_DOCUMENT_ID}, null, null, null);
-            while (cursor.moveToNext()) {
-                final String documentId = cursor.getString(0);
-                final Uri documentUri = DocumentsContract.buildDocumentUriUsingTree(this.uri,
-                        documentId);
-                results.add(documentUri);
+        String uri = this.uri.toString();
+        if ((StorageFile.cache == null) || StorageFile.cacheDirty) {
+            StorageFile.cache = new HashMap<String, StorageFile[]>();
+            StorageFile.cacheDirty = false;
+        }
+        if (StorageFile.cache.get(uri) == null) {
+            final ContentResolver resolver = this.context.getContentResolver();
+            final Uri childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(this.uri,
+                    DocumentsContract.getDocumentId(this.uri));
+            final ArrayList<Uri> results = new ArrayList<>();
+            Cursor cursor = null;
+            //noinspection OverlyBroadCatchBlock
+            try {
+                cursor = resolver.query(childrenUri, new String[]{
+                        DocumentsContract.Document.COLUMN_DOCUMENT_ID}, null, null, null);
+                while (cursor.moveToNext()) {
+                    final String documentId = cursor.getString(0);
+                    final Uri documentUri = DocumentsContract.buildDocumentUriUsingTree(this.uri,
+                            documentId);
+                    results.add(documentUri);
+                }
+            } catch (Exception e) {
+                Log.w(StorageFile.TAG, "Failed query: " + e);
+            } finally {
+                StorageFile.closeQuietly(cursor);
             }
-        } catch (Exception e) {
-            Log.w(StorageFile.TAG, "Failed query: " + e);
-        } finally {
-            StorageFile.closeQuietly(cursor);
+            final Uri[] result = results.toArray(new Uri[0]);
+            final StorageFile[] resultFiles = new StorageFile[result.length];
+            for (int i = 0; i < result.length; i++) {
+                resultFiles[i] = new StorageFile(this, this.context, result[i]);
+            }
+            StorageFile.cache.put(uri, resultFiles);
         }
-        final Uri[] result = results.toArray(new Uri[0]);
-        final StorageFile[] resultFiles = new StorageFile[result.length];
-        for (int i = 0; i < result.length; i++) {
-            resultFiles[i] = new StorageFile(this, this.context, result[i]);
-        }
-        return resultFiles;
+        return StorageFile.cache.get(uri);
     }
+
 
     public boolean renameTo(String displayName) {
         //noinspection OverlyBroadCatchBlock


### PR DESCRIPTION
the changes are small and easy, but because I wrapped code into an if, it looks like a big change.

- the cache is managed in listFiles() only.
- it is a Map indexed by the uri.
- it is invalidated by setting a dirty flag.
- if dirty was set before, the cache is completely removed
- on an empty cache the old body of listFiles is evaluated and the result is stored in the cache

The cache is invalidated at the beginning of getApplicationList().
Any change of the backup folder is usually followed by refreah which invokes getApplicationList.

If StorageFile should ever be used for more general purposes, getApplicationList would not be sufficient.
The more correct way would then be to handle all storage operations by the same class (or a collaborating system of classes) to have full control over all changes on the underlying file system initiated by the app.
Even more correct (changes from outside) would be to use file watchers.